### PR TITLE
promotion from gitops-test to gitops-repo-testing

### DIFF
--- a/services/service-a/base/config/300-deployment.yaml
+++ b/services/service-a/base/config/300-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         app: nginx
         newLabel1: createdInDev
         newLabel2: secondLabelInDev
+        newLabel3: thirdLabelInDev
     spec:
       serviceAccountName: default-main-service-account
       containers:


### PR DESCRIPTION
Promoting service `service-a` at commit `eeaec2a
` from branch `master` in `https://github.com/a-roberts/gitops-test.git`.